### PR TITLE
Adding safe.direcotry git config

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           echo "done!"
 
-      - uses: marvinpinto/action-automatic-releases@1.2.1
+      - uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           automatic_release_tag: "latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2.6-alpine
 
 RUN apk add --no-cache git
+RUN git config --global --add safe.directory /github/workspace
 
 RUN set -x && gem install bundler keycutter
 


### PR DESCRIPTION
Adding git `safe.directory` after seeing the following warning multiple times during publishing
```
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
Setting up access to Github Package Registry
Building the gem
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```