### PR TITLE
SRE-1499 Github Action safe.directory failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:2.6-alpine
 
 RUN apk add --no-cache git
-RUN git config --global --add safe.directory /github/workspace
 
 RUN set -x && gem install bundler keycutter
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,8 @@ if [[ -z "${OWNER}" ]]; then
   exit 2;
 fi
 
+git config --global --add safe.directory /github/workspace
+
 echo "Verifying the version matches the gem version"
 VERSION_TAG=$(echo $GITHUB_REF | cut -d / -f 3)
 GEM_VERSION=$(ruby -e "require 'rubygems'; gemspec = Dir.entries('.').find { |file| file =~ /.*\.gemspec/ }; spec = Gem::Specification::load(gemspec); puts spec.version")


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SRE-1499

Created a `pre-release` in order to test this fix. It is released as the `latest` version: `bodyshopbidsdotcom/gh-action-publish-gem-on-tag@latest`. Once this PR is merged, a new version will be released and will replace `latest`.