### PR TITLE
Use default ruby alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine
+FROM ruby:alpine
 
 RUN apk add --no-cache git
 


### PR DESCRIPTION
The action uses ruby 2.6 which is not supported anymore. 

As a result action fails with error:
```
   > [3/5] RUN set -x && gem install bundler keycutter:
   keycutter
  82.42 ERROR:  Error installing bundler:
  82.42 	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
  82.42 	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.6.10.210.
```

Bump ruby version to default latest, so it should not fail again in this way.