### PR TITLE
add ability to set a working directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,13 @@ inputs:
   owner:
     description: User or organization that owns the package on github
     required: true
+  working-directory:
+    description: Directory to run the build and publish in
+    required: false
 runs:
   using: docker
   image: Dockerfile
   args:
     - ${{ inputs.token }}
     - ${{ inputs.owner }}
+    - ${{ inputs.working-directory }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -l
 GITHUB_TOKEN=$1
 OWNER=$2
+WORKING_DIR=$3
 
 if [[ -z "${GITHUB_TOKEN}" ]]; then
   echo "Github token not provided";
@@ -11,11 +12,23 @@ if [[ -z "${OWNER}" ]]; then
   exit 2;
 fi
 
+if [[ -n "${WORKING_DIR}" ]]; then
+  echo "Changing to directory: ${WORKING_DIR}"
+  if ! cd "./${WORKING_DIR}"; then
+    echo "Failed to change to directory: ${WORKING_DIR}"
+    exit 1
+  fi
+fi
+
 git config --global --add safe.directory /github/workspace
 
 echo "Verifying the version matches the gem version"
 VERSION_TAG=$(echo $GITHUB_REF | cut -d / -f 3)
 GEM_VERSION=$(ruby -e "require 'rubygems'; gemspec = Dir.entries('.').find { |file| file =~ /.*\.gemspec/ }; spec = Gem::Specification::load(gemspec); puts spec.version")
+# pre release versions have a .pre. prefix after the minor version
+# '1.2.3.pre.beta.4' -> '1.2.3-beta.4'
+GEM_VERSION=${GEM_VERSION/.pre./-}
+
 if [[ $VERSION_TAG != $GEM_VERSION ]]; then
   echo "Version tag does not match gem version"
   exit 2;


### PR DESCRIPTION
## What
- Adds the ability to set a different working directory
- adds support for pre-release versions

## Why
- FMWK has repos where the `ruby` package doesn't live in the root directory of the repo
- we do pre-release versions sometimes

## How

- Added a new `working-directory` arg
  - added a new `working-directory` arg to the `action.yml`
  - if `WORKING_DIR` is set, we navigate to that directory. If it's not set, it will use the default directory for the action
    - If the directory does not exist, an error is raised
- replaced `pre` with `-` in order to support pre-release versions.

# Testing

- Successful release [publish](https://github.com/bodyshopbidsdotcom/sable/actions/runs/14269511302/job/39999265471)
  - NOTE: this failed because this version already exists, but all the steps seem to work. Don't really want to publish a new release to test this.
- Successful pre-release [publish](https://github.com/bodyshopbidsdotcom/sable/actions/runs/14269310834)
  - can verify the build on [this branch](https://github.com/bodyshopbidsdotcom/vice-backend/pull/10119)
    NOTE: the gem is installed correctly, but tests are failing due to changes in `0.23.1` that aren't supported in VBE yet.
- Successfully raises error when [directory doesn't exist](https://github.com/bodyshopbidsdotcom/sable/actions/runs/14269915464/job/40000538231)
  